### PR TITLE
Fix some compiler warnings from GCC C and C++ compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.bak
 **/.pytest_cache
 **/__pycache__
+.vscode

--- a/src/api/c/spectral_wave_data.h
+++ b/src/api/c/spectral_wave_data.h
@@ -91,7 +91,7 @@ void *swd_api_allocate(const char *file_swd, real_swd x0, real_swd y0,
     1004: invalid input parameters
     1005: Not able to allocate memory
 
-   /**/
+   */
 
 // destructor
 void swd_api_close(void *swd);

--- a/src/api/cpp/SpectralWaveData.cpp
+++ b/src/api/cpp/SpectralWaveData.cpp
@@ -8,8 +8,7 @@ This implementation is based on establishing wrappers to the C-implementation.
 
 Ver-3.0:
 Coded by: Jens B. Helmers DNVGL,  2019.08.11
-
-/**/
+*/
 
 SpectralWaveData::SpectralWaveData(
     std::string file_swd,     // Name of actual SWD file

--- a/src/api/cpp/SpectralWaveData.h
+++ b/src/api/cpp/SpectralWaveData.h
@@ -100,7 +100,7 @@ public:
     SwdInputValueException:     Input arguments for class methods are not sound
     SwdAllocateException:       Not able to allocate internal SWD storage
 
-    /**/
+    */
 
     ~SpectralWaveData();
 
@@ -206,4 +206,4 @@ public:
     void ExceptionClear();
 
 };
-#endif SWD_CPP_H_INCLUDED
+#endif // SWD_CPP_H_INCLUDED

--- a/src/api_examples/application_swd_api.c
+++ b/src/api_examples/application_swd_api.c
@@ -39,7 +39,7 @@ bool dc_bias = false;   // Suppress contributions from zero-frequency
 swd = swd_api_allocate(file_swd, x0, y0, t0, beta, rho, nsumx, nsumy, 
                        impl, ipol, norder, dc_bias);
 if (swd_api_error_raised(swd)) {
-    fprintf(stderr, swd_api_error_get_msg(swd));
+    fprintf(stderr, "%s", swd_api_error_get_msg(swd));
     exit(EXIT_FAILURE); /* indicate failure.*/
 }
 
@@ -49,7 +49,7 @@ while (t < tmax) {
     // Tell the swd object current application time...
     swd_api_update_time(swd, t);
     if (swd_api_error_raised(swd)) {   // t is too big...
-        fprintf(stderr, swd_api_error_get_msg(swd));
+        fprintf(stderr, "%s", swd_api_error_get_msg(swd));
         exit(EXIT_FAILURE); 
     }
 
@@ -104,7 +104,7 @@ while (t < tmax) {
     // elevation and pressure converge as a function of number of spectral components
     swd_api_convergence(swd, x, y, z, "dump.csv");
     if (swd_api_error_raised(swd)) { /* in rare cases you could not open the CSV file...*/
-        fprintf(stderr, swd_api_error_get_msg(swd));
+        fprintf(stderr, "%s", swd_api_error_get_msg(swd));
         exit(EXIT_FAILURE);
     }
 
@@ -118,7 +118,7 @@ while (t < tmax) {
 // In this case we only care about the time interval [100.0, 200.0]
 swd_api_strip(swd, 100.0, 200.0, "stripped.swd");
 if (swd_api_error_raised(swd)) { /* if t=[100.0, 200.0] is not a proper interval...*/
-    fprintf(stderr, swd_api_error_get_msg(swd));
+    fprintf(stderr, "%s", swd_api_error_get_msg(swd));
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
# Compiler warnings fixed:

From gcc/g++/gfortran version 9.3.0 on Ubuntu 20.04

## `/*` inside multiline comment

Remove some /**/ at the ends of multi-line comments, replace with */

## `fprintf(...)` format not a string literal and no format arguments

   -Wformat-security
   See e.g.
   https://en.wikipedia.org/wiki/Uncontrolled_format_string

