### PR TITLE
CMake cleanup - only list fortran files to include once

### DIFF
--- a/src/api/c/Cmake/CMakeLists.txt
+++ b/src/api/c/Cmake/CMakeLists.txt
@@ -12,22 +12,12 @@ set(DIR_SRC_API_F ../../fortran)
 set(DIR_SRC_API_C ..)
 set(DIR_SRC_C_APP ../../../api_examples)
 
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind values from the C directory
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.f90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
-    ${DIR_SRC_API_C}/kind_values.f90     # Note we apply from the C-directory
+    ${SRC_CORE}
+    ${DIR_SRC_API_C}/kind_values.f90 
 )
 
 set(SRC_C_APP

--- a/src/api/c/Cmake/CMakeLists_LibStatic.txt
+++ b/src/api/c/Cmake/CMakeLists_LibStatic.txt
@@ -12,22 +12,13 @@ set(CMAKE_BUILD_TYPE Release)
 set(DIR_SRC_API_F ../../../fortran)
 set(DIR_SRC_API_C ../../../c)
 
+
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind values from the C directory
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.F90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
-    ${DIR_SRC_API_C}/kind_values.f90     # Note we apply from the C-directory
+    ${SRC_CORE}
+    ${DIR_SRC_API_C}/kind_values.f90
 )
 
 add_library(${LIB} STATIC ${SRC_API_F})

--- a/src/api/cpp/Cmake/CMakeLists.txt
+++ b/src/api/cpp/Cmake/CMakeLists.txt
@@ -13,22 +13,12 @@ set(DIR_SRC_API_C ../../c)
 set(DIR_SRC_API_CPP ..)
 set(DIR_SRC_APP ../../../api_examples)
 
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind values from the C++ directory
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.f90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
-    ${DIR_SRC_API_CPP}/kind_values.f90     # Note we apply from the C++ directory
+    ${SRC_CORE}
+    ${DIR_SRC_API_CPP}/kind_values.f90
 )
 
 set(SRC_CPP

--- a/src/api/cpp/Cmake/CMakeLists_LibStatic.txt
+++ b/src/api/cpp/Cmake/CMakeLists_LibStatic.txt
@@ -13,22 +13,12 @@ set(DIR_SRC_API_F ../../../fortran)
 set(DIR_SRC_API_C ../../../c)
 set(DIR_SRC_API_CPP ../..)
 
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind values from the C++ directory
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.F90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
-    ${DIR_SRC_API_CPP}/kind_values.f90     # Note we apply from the C++ directory
+    ${SRC_CORE}
+    ${DIR_SRC_API_CPP}/kind_values.f90
 )
 
 add_library(${LIB} STATIC ${SRC_API_F})

--- a/src/api/fortran/Cmake/CMakeLists.txt
+++ b/src/api/fortran/Cmake/CMakeLists.txt
@@ -11,26 +11,12 @@ project(${PROG} Fortran)
 set(DIR_SRC_API_F ../../fortran)
 set(DIR_SRC_APP ../../../api_examples)
 
+include(core_files.cmake)
+
+# Core files plus kind_values.f90
 set(SRC_SWDLIB
-  ${DIR_SRC_API_F}/open_swd_file.f90
-  ${DIR_SRC_API_F}/spectral_interpolation.f90
-  ${DIR_SRC_API_F}/spectral_wave_data.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-  ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-  ${DIR_SRC_API_F}/swd_write_shape_1_or_2.f90
-  ${DIR_SRC_API_F}/swd_write_shape_3.f90
-  ${DIR_SRC_API_F}/swd_write_shape_4_or_5.f90
-  ${DIR_SRC_API_F}/swd_write_shape_6.f90
-  ${DIR_SRC_API_F}/kind_values.f90
-  ${DIR_SRC_API_F}/swd_version.f90)
+  ${SRC_CORE}
+  ${DIR_SRC_API_F}/kind_values.f90)
 
 set(SRC_APP
     ${DIR_SRC_APP}/application_swd_api.f90

--- a/src/api/fortran/Cmake/CMakeLists_LibStatic.txt
+++ b/src/api/fortran/Cmake/CMakeLists_LibStatic.txt
@@ -11,20 +11,11 @@ set(CMAKE_BUILD_TYPE Release)
 
 set(DIR_SRC_API_F ../../../fortran)
 
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind_values.f90
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.F90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
+    ${SRC_CORE}
     ${DIR_SRC_API_F}/kind_values.f90
 )
 

--- a/src/api/fortran/Cmake/core_files.cmake
+++ b/src/api/fortran/Cmake/core_files.cmake
@@ -1,0 +1,21 @@
+# All the Fortran implementation source files except kind_values.f90
+# You need to define DIR_SRC_API_F before include()-ing this file
+set(SRC_CORE
+  ${DIR_SRC_API_F}/open_swd_file.f90
+  ${DIR_SRC_API_F}/spectral_interpolation.f90
+  ${DIR_SRC_API_F}/spectral_wave_data.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_c.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_error.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
+  ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
+  ${DIR_SRC_API_F}/swd_write_shape_1_or_2.f90
+  ${DIR_SRC_API_F}/swd_write_shape_3.f90
+  ${DIR_SRC_API_F}/swd_write_shape_4_or_5.f90
+  ${DIR_SRC_API_F}/swd_write_shape_6.f90
+  ${DIR_SRC_API_F}/swd_version.f90)

--- a/src/api/fortran/Cmake/core_files.cmake
+++ b/src/api/fortran/Cmake/core_files.cmake
@@ -19,3 +19,12 @@ set(SRC_CORE
   ${DIR_SRC_API_F}/swd_write_shape_4_or_5.f90
   ${DIR_SRC_API_F}/swd_write_shape_6.f90
   ${DIR_SRC_API_F}/swd_version.f90)
+
+# Enable C++ style pre-processor directives for files that use them
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    set_source_files_properties(
+      ${DIR_SRC_API_F}/open_swd_file.f90
+      PROPERTIES
+      COMPILE_FLAGS
+      -cpp)
+endif()

--- a/src/api/fortran/Cmake/core_files.cmake
+++ b/src/api/fortran/Cmake/core_files.cmake
@@ -19,3 +19,9 @@ set(SRC_CORE
   ${DIR_SRC_API_F}/swd_write_shape_4_or_5.f90
   ${DIR_SRC_API_F}/swd_write_shape_6.f90
   ${DIR_SRC_API_F}/swd_version.f90)
+
+# Bundle the Intel compiler libraries when compiling shared libraries on Linux
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" AND UNIX)
+    message("SWD: enabling -static-intel for .so files")
+    set(CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_Fortran_FLAGS} -static-intel")
+endif()

--- a/src/api/fortran/Cmake/core_files.cmake
+++ b/src/api/fortran/Cmake/core_files.cmake
@@ -1,7 +1,7 @@
 # All the Fortran implementation source files except kind_values.f90
 # You need to define DIR_SRC_API_F before include()-ing this file
 set(SRC_CORE
-  ${DIR_SRC_API_F}/open_swd_file.f90
+  ${DIR_SRC_API_F}/open_swd_file.F90
   ${DIR_SRC_API_F}/spectral_interpolation.f90
   ${DIR_SRC_API_F}/spectral_wave_data.f90
   ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
@@ -19,12 +19,3 @@ set(SRC_CORE
   ${DIR_SRC_API_F}/swd_write_shape_4_or_5.f90
   ${DIR_SRC_API_F}/swd_write_shape_6.f90
   ${DIR_SRC_API_F}/swd_version.f90)
-
-# Enable C++ style pre-processor directives for files that use them
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    set_source_files_properties(
-      ${DIR_SRC_API_F}/open_swd_file.f90
-      PROPERTIES
-      COMPILE_FLAGS
-      -cpp)
-endif()

--- a/src/api/python/Cmake/CMakeLists.txt
+++ b/src/api/python/Cmake/CMakeLists.txt
@@ -13,22 +13,12 @@ set(DIR_SRC_API_F ../../fortran)
 set(DIR_SRC_API_C ../../c)
 set(DIR_SRC_API_PY ..)
 
+include(${DIR_SRC_API_F}/Cmake/core_files.cmake)
+
+# Core files plus kind values from the Python directory
 set(SRC_API_F
-    ${DIR_SRC_API_F}/open_swd_file.F90
-    ${DIR_SRC_API_F}/spectral_interpolation.f90
-    ${DIR_SRC_API_F}/spectral_wave_data.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_allocate.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_c.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_error.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_1_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_2_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_3_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_4_impl_2.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_5_impl_1.f90
-    ${DIR_SRC_API_F}/spectral_wave_data_shape_6_impl_1.f90
-    ${DIR_SRC_API_F}/swd_version.f90
-    ${DIR_SRC_API_PY}/kind_values.f90     # Note we apply from the Python-directory
+    ${SRC_CORE}
+    ${DIR_SRC_API_PY}/kind_values.f90
 )
 
 add_library(${LIB} SHARED ${SRC_API_F})


### PR DESCRIPTION
The CMake files are cleaned up to avoid repeating the list of Fortran files in every `CMakeLists.txt` file.

**Note**: I included all Fortran files in all CMake recipes. Some of them were missing the `swd_write*` files. I do not know if this was important or not. They all seem to compile just fine with all files included.